### PR TITLE
Scratchpad audio fix for issue #4

### DIFF
--- a/.config/herbstluftwm/autostart
+++ b/.config/herbstluftwm/autostart
@@ -29,4 +29,12 @@ hc detect_monitors
 for monitor in $(hc list_monitors | cut -d':' -f1); do
   hc pad $monitor 25
 done
+
+#-----------#
+# Autostart #
+#-----------#
+audio &
+pactl load-module module-null-sink sink_name="System Audio"
+pactl load-module module-null-sink sink_name="Discord Audio"
+jack_mixer -c ~/.local/share/jack_mixer/master.xml &
 polybar_launcher &


### PR DESCRIPTION
Add pulseaudio sinks to split audio for streaming at startup. Add autostart for jack_mixer with master config file. Move scratchpad preload below sourceing bindings (to load other tags first). Fixes #4